### PR TITLE
Switch from `functions` to `tools`

### DIFF
--- a/test/bot_team/chat_gpt_request_test.rb
+++ b/test/bot_team/chat_gpt_request_test.rb
@@ -7,7 +7,6 @@ describe ChatGptRequest do
 
   it 'should initialize with defaults' do
     assert_equal 'gpt-3.5-turbo-0613', subject.model
-    assert_equal 'auto', subject.function_call
     assert_equal 80, subject.max_tokens
     assert_equal [], subject.messages
     assert_equal [], subject.functions


### PR DESCRIPTION
Switches to functions, but still runs all the calls in every choice when performing `multiple_function_calls`