### PR TITLE
[bug][agent] Bug in redundant (unused?) state map processing

### DIFF
--- a/lib/bot_team/chat_gpt_agent.rb
+++ b/lib/bot_team/chat_gpt_agent.rb
@@ -197,7 +197,7 @@ class ChatGptAgent # rubocop:disable Metrics/ClassLength
     params = args.transform_keys(&:to_sym)
 
     if state_function == response.function_name.to_sym
-      return process_state_function_response(state_function_action_params(params))
+      return process_state_function_response(params:)
     end
 
     response.function_calls.each do |function_call|


### PR DESCRIPTION
I'm not entirely sure what we have state map processing in agent and in runner... It's not exercised by tests in agent, so maybe we should rip it out? But this at least makes it in both places 🤷