### PR TITLE
Remove "require 'pry'" for memory usage reasons

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bot_team (0.2.0)
+    bot_team (0.2.1)
       httparty (~> 0.21.0)
       logger (~> 1.5.0)
 

--- a/lib/bot_team.rb
+++ b/lib/bot_team.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'logger'
-require 'pry'
 
 require_relative 'bot_team/agent_runner'
 require_relative 'bot_team/chat_gpt_agent'

--- a/lib/bot_team/version.rb
+++ b/lib/bot_team/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module BotTeam
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end


### PR DESCRIPTION
I'm not sure what all in involved in publishing a version bump